### PR TITLE
[WIP] Use hyperlog

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,13 @@
 var IndexedTarball = require('indexed-tarball')
 var itar = require('indexed-tarball-blob-store')
-var tar = require('tar-stream')
-var Osm = require('osm-p2p')
+var tar = require('tar-fs')
+var level = require('level')
+var hyperlog = require('hyperlog')
 var path = require('path')
 var once = require('once')
 var fs = require('fs')
-var through = require('through2')
 var rimraf = require('rimraf')
 var mkdirp = require('mkdirp')
-var readdirp = require('readdirp')
 var pump = require('pump')
 var debug = require('debug')('osm-p2p-syncfile')
 var readyify = require('./lib/readyify')
@@ -16,7 +15,9 @@ var readyify = require('./lib/readyify')
 module.exports = Syncfile
 
 // syncfile data format version
-var VERSION = '1.0.0'
+var VERSION = '2'
+// used to identify indexed tarball as a syncfile
+var TYPE = 'MAPEO-SYNCFILE'
 
 var State = {
   INIT:    1,
@@ -32,49 +33,44 @@ function Syncfile (filepath, tmpdir, opts) {
   if (!tmpdir || typeof tmpdir !== 'string') throw new Error('must specify tmpdir to use')
 
   this._state = State.INIT
-  this._tmpdir = tmpdir
 
   var self = this
-  this._ready = readyify(function (done) {
-    try {
-      var exists = fs.existsSync(filepath)
-      self.tarball = new IndexedTarball(filepath, opts)
-      if (!exists) {
-        self.tarball.userdata({version: VERSION, syncfile: {}}, extract)
-      } else {
-        extract()
-      }
+  this._ready = readyify(openAndInitialize)
 
-      function extract (err) {
-        if (err) {
-          self._state = State.ERROR
-          self._error = err
-          done(err)
-          return
-        }
-        self._extractOsm(function (err) {
-          if (err) {
-            self._state = State.ERROR
-            self._error = err
-            done(err)
-          } else {
-            self._state = State.READY
-            done()
-          }
-        })
-      }
-    } catch (e) {
-      self._state = State.ERROR
-      self._error = e
-      done(e)
+  function openAndInitialize (cb) {
+    var exists = fs.existsSync(filepath)
+    var tarball = self.tarball = new IndexedTarball(filepath, opts)
+    if (!exists) {
+      tarball.userdata({ version: VERSION, type: TYPE, metadata: {} }, onOpen)
+    } else {
+      validateTarball(tarball, onOpen)
     }
-  })
+
+    function onOpen (err) {
+      if (err) return cb(err)
+      var syncdir = path.join(tmpdir, 'osm-p2p-syncfile-' + Math.random().toString().substring(2))
+      self._syncdir = syncdir
+      mkdirp(syncdir, function (err) {
+        if (err) return cb(err)
+        extractHyperlog(tarball, syncdir, onExtract)
+      })
+    }
+
+    function onExtract (err, log) {
+      if (err) return cb(err)
+      self.media = itar({ tarball: tarball })
+      self.log = log
+      self.opened = true
+      cb()
+    }
+  }
 }
 
 Syncfile.prototype.ready = function (cb) {
-  if (this._state === State.CLOSED) return process.nextTick(cb, new Error('syncfile is closed'))
-  else if (this._state === State.CLOSING) return process.nextTick(cb, new Error('syncfile is closed'))
-  else this._ready(cb)
+  if (this._state === State.CLOSED || this._state === State.CLOSING) {
+    return process.nextTick(cb, new Error('syncfile is closed'))
+  }
+  this._ready(cb)
 }
 
 Syncfile.prototype.userdata = function (data, cb) {
@@ -82,158 +78,131 @@ Syncfile.prototype.userdata = function (data, cb) {
     cb = data
     data = null
   }
-
-  if (this._state !== State.READY) {
-    return cb(new Error('syncfile is not ready'))
+  var self = this
+  if (!this.opened) {
+    return this.ready(function (err) {
+      if (err) return cb(err)
+      self.userdata(data, cb)
+    })
   }
 
   if (!data) {
     this.tarball.userdata(function (err, data) {
       if (err) return cb(err)
-      cb(null, data.syncfile || {})
+      cb(null, data.metadata || {})
     })
   } else {
-    this.tarball.userdata({version: VERSION, syncfile: data}, cb)
+    this.tarball.userdata({ version: VERSION, type: TYPE, metadata: data }, cb)
   }
 }
 
 Syncfile.prototype.close = function (cb) {
-  cb = once(cb)
-
-  var self = this
-
-  switch (this._state) {
-    case State.INIT:
-      process.nextTick(cb, new Error('syncfile is still opening'))
-      return
-    case State.ERROR:
-      process.nextTick(cb, this._error)
-      return
-    case State.CLOSED:
-      process.nextTick(cb, new Error('syncfile is already closed'))
-      return
-    case State.CLOSING:
-      process.nextTick(cb, new Error('syncfile is already closed'))
-      return t
+  if (this._state === State.CLOSED || this._state === State.CLOSING) {
+    return process.nextTick(cb, new Error('syncfile is closed'))
   }
-
+  var self = this
+  if (!this.opened) {
+    return this.ready(function (err) {
+      if (err) return cb(err)
+      self.close(cb)
+    })
+  }
   this._state = State.CLOSING
-  var osm = this.osm
-  this.osm = undefined
+  var log = this.log
+  this.log = undefined
   this.media = undefined
 
-  osm.ready(function () {
-    // re-pack syncfile p2p-db dir into tarball
-    var tarPath = path.join(self._syncdir, 'osm-p2p-db.tar')
-    var tarSize = 0
-    var tcount = through(function (chunk, _, next) { tarSize += chunk.length; next(null, chunk) })
-
-    // 1. create new tar.pack() stream, to be piped to fs.createWriteStream inside self._syncdir
-    var pack = tar.pack()
-
-    // 2. recursively walk files in self._syncdir (skip new tar file)
-    var rd = readdirp({root: path.join(self._syncdir, 'osm')})
-
-    // 3. write all to the tar file
-    var twrite = through.obj(function (file, _, next) {
-      if (file.path === 'osm-p2p-db.tar') return next()
-      debug('file', file.fullPath, file.stat.size)
-      var entry = pack.entry({ name: file.path, size: file.stat.size }, function (err) {
-        debug('wrote', file.path)
-        if (err) return next(err)
-        else next()
-      })
-      pump(fs.createReadStream(file.fullPath), entry)
-    })
-
-    // 4. pipe them together
-    pump(rd, twrite, function (err) {
-      debug('finalizing')
-      if (!err) pack.finalize()
-      else cb(err)
-    })
-    pump(pack, tcount, fs.createWriteStream(tarPath), function (err) {
-      if (err) return cleanup(err)
-
-      debug('done', tarPath, tarSize)
-
-      // 5. write tar file to self.tarball.append()
-      fs.createReadStream(tarPath)
-        .pipe(self.tarball.append('osm-p2p-db.tar', cleanup))
-    })
+  log.db.close(function (err) {
+    if (err) return cb(err)
+    var ws = self.tarball.append('osm-p2p-log.tar', cleanup)
+    tar.pack(self._syncdir).pipe(ws)
   })
 
   // clean up tmp dir
   function cleanup (err) {
-    osm.close(function (err2) {
-      rimraf(self._syncdir, function (err3) {
-        err = err || err2 || err3
-        cb(err)
-      })
+    if (err) return cb(err)
+    rimraf(self._syncdir, function (err) {
+      if (err) return cb(err)
+      this._state = State.CLOSED
+      cb()
     })
   }
 }
 
-Syncfile.prototype._extractOsm = function (cb) {
+// Extract a hyperlog from an indexed tarball or create a new one, putting it in
+// the dir `syncdir`
+function extractHyperlog (tarball, syncdir, cb) {
   cb = once(cb)
-  var self = this
 
-  // 1. decide on tmp directory
-  var syncdir = path.join(this._tmpdir, 'osm-p2p-syncfile-' + Math.random().toString().substring(2))
-  this._syncdir = syncdir
-
-  // 2. create tmp sync dir
-  mkdirp(syncdir, function (err) {
+  tarball.list(function (err, files) {
     if (err) return cb(err)
-
-    // 3. check if p2p db exists in archive
-    self.tarball.list(function (err, files) {
-      if (err) return cb(err)
-      if (files.indexOf('osm-p2p-db.tar') === -1) {
-        setupVars()
-      } else {
-        existingDb()
-      }
-    })
+    if (files.indexOf('osm-p2p-log.tar') > -1) {
+      extractLog(onExtract)
+    } else if (files.indexOf('osm-p2p-db.tar') > -1) {
+      // v1 put the whole osm folder in the sync file
+      extractLogFromOsm(onExtract)
+    } else {
+      process.nextTick(onExtract)
+    }
   })
 
-  function existingDb () {
-    // find p2p archive in db (last file) and decompress through tar-stream
-    // and finally to disk
-    var rs = self.tarball.read('osm-p2p-db.tar')
-    rs.on('error', cb)
-
-    // TODO(noffle): wrap this in a helper function: extract-tar-to-fs
-    var ex = tar.extract()
-
-    pump(rs, ex, function (err) {
-      debug('tar stream finish')
-      if (err) cb(err)
-      else self.tarball.pop(cb)
-    })
-
-    ex.on('entry', function (header, stream, next) {
-      debug('extracting', header.name)
-      mkdirp(path.dirname(path.join(syncdir, 'osm', header.name)), function (err) {
-        if (err) return next(err)
-        var ws = fs.createWriteStream(path.join(syncdir, 'osm', header.name))
-        pump(stream, ws, function (err) {
-          debug('extracted', header.name)
-          next(err)
-        })
-      })
-    })
-
-    ex.on('finish', function () {
-      debug('tar finish')
-      setupVars()
-    })
+  function extractLog (cb) {
+    var rs = tarball.read('osm-p2p-log.tar')
+    var ex = tar.extract(syncdir)
+    pump(rs, ex, cb)
   }
 
-  function setupVars (err) {
+  function extractLogFromOsm (cb) {
+    var rs = tarball.read('osm-p2p-db.tar')
+    // extract the `log/` folder to the syncdir.
+    // this looks weird because in tar-fs map runs before ignore
+    var ex = tar.extract(syncdir, {
+      ignore: function (_, header) {
+        return header.name.startsWith('IGNORE-')
+      },
+      map: function (header) {
+        if (header.name.startsWith('log/')) {
+          header.name = header.name.replace(/^log\//, '')
+        } else {
+          header.name = 'IGNORE-' + header.name
+        }
+      }
+    })
+    pump(rs, ex, cb)
+  }
+
+  function onExtract (err) {
     if (err) return cb(err)
-    self.osm = Osm(path.join(syncdir, 'osm'))
-    self.media = itar({tarball: self.tarball})
-    self.osm.ready(cb)
+    try {
+      var db = level(syncdir)
+      var log = hyperlog(db, { valueEncoding: 'json' })
+      cb(null, log)
+    } catch (err) {
+      cb(err)
+    }
   }
+}
+
+// Check this is actually a syncfile and is a version that we can read
+function validateTarball (tarball, cb) {
+  tarball.userdata(function (err, data) {
+    if (err) return cb(err)
+    data = data || {}
+    if (data.version === '1.0.0') return upgradeFromV1(tarball, data, cb)
+    if (data.type !== TYPE) return cb(new Error('File is not a mapeo syncfile'))
+    if (data.version !== VERSION) return cb(new Error('Unknown syncfile version'))
+    cb()
+  })
+}
+
+// Very small breaking change, I don't think we have any syncfiles actually out
+// in the wild right now. But v2 also only stores the hyperlog, not the whole
+// osm folder with the indexes
+function upgradeFromV1 (tarball, data, cb) {
+  var v2Userdata = {
+    version: VERSION,
+    type: TYPE,
+    medatadata: data.syncfile || {}
+  }
+  tarball.userdata(v2Userdata, cb)
 }

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var mkdirp = require('mkdirp')
 var pump = require('pump')
 var debug = require('debug')('osm-p2p-syncfile')
 var readyify = require('./lib/readyify')
+var tarSize = require('./lib/tar_size')
 
 module.exports = Syncfile
 
@@ -116,8 +117,11 @@ Syncfile.prototype.close = function (cb) {
 
   log.db.close(function (err) {
     if (err) return cb(err)
-    var ws = self.tarball.append('osm-p2p-log.tar', cleanup)
-    tar.pack(self._syncdir).pipe(ws)
+    tarSize(self._syncdir, function (err, size) {
+      if (err) return cb(err)
+      var ws = self.tarball.append('osm-p2p-log.tar', size, cleanup)
+      tar.pack(self._syncdir).pipe(ws)
+    })
   })
 
   // clean up tmp dir

--- a/index.js
+++ b/index.js
@@ -22,9 +22,8 @@ var TYPE = 'MAPEO-SYNCFILE'
 var State = {
   INIT:    1,
   READY:   2,
-  ERROR:   3,
-  CLOSING: 4,
-  CLOSED:  5
+  CLOSING: 3,
+  CLOSED:  4
 }
 
 function Syncfile (filepath, tmpdir, opts) {
@@ -60,7 +59,7 @@ function Syncfile (filepath, tmpdir, opts) {
       if (err) return cb(err)
       self.media = itar({ tarball: tarball })
       self.log = log
-      self.opened = true
+      self._state = State.READY
       cb()
     }
   }
@@ -79,7 +78,7 @@ Syncfile.prototype.userdata = function (data, cb) {
     data = null
   }
   var self = this
-  if (!this.opened) {
+  if (this._state === State.INIT) {
     return this.ready(function (err) {
       if (err) return cb(err)
       self.userdata(data, cb)
@@ -101,7 +100,7 @@ Syncfile.prototype.close = function (cb) {
     return process.nextTick(cb, new Error('syncfile is closed'))
   }
   var self = this
-  if (!this.opened) {
+  if (this._state === State.INIT) {
     return this.ready(function (err) {
       if (err) return cb(err)
       self.close(cb)

--- a/index.js
+++ b/index.js
@@ -73,6 +73,9 @@ Syncfile.prototype.ready = function (cb) {
 }
 
 Syncfile.prototype.userdata = function (data, cb) {
+  if (this._state === State.CLOSED || this._state === State.CLOSING) {
+    return process.nextTick(cb, new Error('syncfile is closed'))
+  }
   if (!cb && typeof data === 'function') {
     cb = data
     data = null

--- a/lib/readyify.js
+++ b/lib/readyify.js
@@ -1,21 +1,24 @@
-module.exports = function (work) {
+module.exports = function readyify (work) {
   var fns = []
+  var isReady = false
+  var error
 
-  var res = function (fn) {
-    if (!res.ready) fns.push(fn)
-    else process.nextTick(fn, res.error)
+  // This function will queue up tasks which will run when work is done
+  function readyFn (fn) {
+    if (!isReady) fns.push(fn)
+    else process.nextTick(fn, error)
   }
-  res.error = undefined
-  res.ready = false
 
-  process.nextTick(function () {
-    work(function (err) {
-      res.ready = true
-      res.error = err
-      fns.forEach(function (fn) {
-        process.nextTick(fn, err)
-      })
+  // When work is done, call all queued functions
+  function done (err) {
+    isReady = true
+    error = err
+    fns.forEach(function (fn) {
+      process.nextTick(fn, err)
     })
-  })
-  return res
+  }
+
+  process.nextTick(work, done)
+
+  return readyFn
 }

--- a/lib/tar_size.js
+++ b/lib/tar_size.js
@@ -1,0 +1,27 @@
+var through2 = require('through2')
+var pump = require('pump')
+var tar = require('tar-fs')
+var once = require('once')
+
+module.exports = tarSize
+
+function tarSize (filepath, cb) {
+  cb = once(cb)
+  var ws = sizeStream()
+  ws.on('size', function (size) {
+    cb(null, size)
+  })
+  pump(tar.pack(filepath), ws, function (err) {
+    if (err) cb(err)
+  })
+}
+
+function sizeStream () {
+  var size = 0
+  return through2(function (chunk, enc, next) {
+    size += chunk.length
+    next()
+  }, function flush (next) {
+    this.emit('size', size)
+  })
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "rimraf": "^2.6.2",
     "tar-fs": "^2.0.0",
     "tar-stream": "^1.6.1",
-    "through2": "^2.0.3"
+    "through2": "^2.0.5"
   },
   "devDependencies": {
     "abstract-blob-store": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -12,14 +12,17 @@
   "dependencies": {
     "blob-store-replication-stream": "^1.1.1",
     "debug": "^3.1.0",
+    "hyperlog": "^4.12.1",
     "indexed-tarball": "^3.1.0",
     "indexed-tarball-blob-store": "^1.1.0",
+    "level": "^4.0.0",
     "mkdirp": "^0.5.1",
     "once": "^1.4.0",
     "osm-p2p": "^2.0.0",
     "pump": "^3.0.0",
     "readdirp": "^2.1.0",
     "rimraf": "^2.6.2",
+    "tar-fs": "^2.0.0",
     "tar-stream": "^1.6.1",
     "through2": "^2.0.3"
   },

--- a/test/create.js
+++ b/test/create.js
@@ -26,7 +26,7 @@ test('can initialize with new syncfile', function (t) {
 
       syncfile.tarball.userdata(function (err, data) {
         t.error(err)
-        t.deepEquals(data, {version: '1.0.0', syncfile: {}})
+        t.deepEquals(data, {version: '2', type: 'MAPEO-SYNCFILE', metadata: {}})
 
         syncfile.close(function (err) {
           t.error(err)

--- a/test/tar_size.js
+++ b/test/tar_size.js
@@ -1,0 +1,27 @@
+var tarSize = require('../lib/tar_size')
+var tar = require('tar-fs')
+var tmp = require('tmp')
+var test = require('tape')
+var pump = require('pump')
+var fs = require('fs')
+
+test('size calculation is correct', function (t) {
+  var dirToSizeup = __dirname
+  var tarFilename = tmp.tmpNameSync()
+  var calculatedSize
+  var pending = 2
+
+  pump(tar.pack(dirToSizeup), fs.createWriteStream(tarFilename), done)
+  tarSize(dirToSizeup, function (err, size) {
+    calculatedSize = size
+    done(err)
+  })
+
+  function done (err) {
+    t.error(err, 'no error')
+    if (--pending > 0) return
+    var stats = fs.statSync(tarFilename)
+    t.equal(calculatedSize, stats.size, 'calculated size matches disk size')
+    t.end()
+  }
+})


### PR DESCRIPTION
The goal of this PR is to only store the hyperlog in the syncfile, not the whole osm-p2p-db. The indexes take up a lot of space and take time to create, and they are not used in the sync file.

This PR also tries to clean up some of the logic to make it easier to review and debug:

- It uses tar-fs for extracting/packing tarballs
- It tries to reduce the number of states that can exist, which make debugging which methods work when more difficult
- It tries to keep logic that modifies state (e.g. changing properties on `this`) in one place

Todo:

- [ ] Will currently fail if appending the hyperlog will bring the indexed tarball over the max size
- [ ] Need to fix tests to work without osm
- [ ] Need to add test for backwards compatibility
- [ ] Rename to "mapeo-sync-file"?
