### PR TITLE
Throw error on replicate if not ready (fixes #8)

### DIFF
--- a/test/replicate.js
+++ b/test/replicate.js
@@ -29,6 +29,25 @@ test('try to replicate before ready', function (t) {
   })
 })
 
+test('try to replicate after close', function (t) {
+  t.plan(3)
+
+  tmp.dir(function (err, dir, cleanup) {
+    t.error(err)
+
+    var filepath = path.join(dir, 'sync.tar')
+    var syncfile = Syncfile(filepath, dir)
+    syncfile.ready(function () {
+      syncfile.close(onClose)
+    })
+
+    function onClose () {
+      t.notOk(syncfile.replicateData, 'replicateData does not exist')
+      t.notOk(syncfile.replicateMedia, 'replicateMedia does not exist')
+    }
+  })
+})
+
 test('replicate media + osm-p2p to syncfile', function (t) {
   tmp.dir(function (err, dir, cleanup) {
     t.error(err)

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -24,8 +24,8 @@ test('try to replicate before ready', function (t) {
     var filepath = path.join(dir, 'sync.tar')
     var syncfile = Syncfile(filepath, dir)
 
-    t.notOk(syncfile.replicateData, 'replicateData does not exist')
-    t.notOk(syncfile.replicateMedia, 'replicateMedia does not exist')
+    t.throws(syncfile.replicateData, 'replicateData() throws when not ready')
+    t.throws(syncfile.replicateMedia, 'replicateMedia() throws when not ready')
   })
 })
 
@@ -42,8 +42,8 @@ test('try to replicate after close', function (t) {
     })
 
     function onClose () {
-      t.notOk(syncfile.replicateData, 'replicateData does not exist')
-      t.notOk(syncfile.replicateMedia, 'replicateMedia does not exist')
+      t.throws(syncfile.replicateData, 'replicateData() throws when closed')
+      t.throws(syncfile.replicateMedia, 'replicateMedia() throws when closed')
     }
   })
 })


### PR DESCRIPTION
Currently the `replicateData()` and `replicateMedia()` methods are undefined before the syncfile is ready, and after `close()` they fail without error.

This PR defines the methods always, but throws an error when the syncfile is not ready.
