### PR TITLE
chore: Run tests on Node versions used in apps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
 - '8'
-- '10'
+- '10.13.0'
+- '12.4.0'
+- '12.14.1'
 os:
 - windows
 - osx


### PR DESCRIPTION
Mapeo Mobile currently runs on Node v10.13.0
Mapeo Desktop (electron v6.1.7) runs on Node v12.4.0
Latest electron is Node v12.14.1