### PR TITLE
Remove tmp files after sync

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,7 +197,7 @@ Syncfile.prototype.close = function (cb) {
   // clean up tmp dir
   function cleanup (err) {
     mfeed.close(function (err2) {
-      rimraf(self._syncdir, function (err3) {
+      rimraf(self._tmpdir, function (err3) {
         var error = err || err2 || err3
         cb(error)
       })

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function Syncfile (filepath, tmpdir, opts) {
   if (!tmpdir || typeof tmpdir !== 'string') throw new Error('must specify tmpdir to use')
 
   this._state = State.INIT
-  this._tmpdir = tmpdir
+  this._tmpdir =   this._tmpdir = path.join(tmpdir, 'osm-p2p-syncfile-tmp')
 
   opts = opts || {}
 

--- a/test/create.js
+++ b/test/create.js
@@ -30,6 +30,7 @@ test('can initialize with new syncfile', function (t) {
 
         syncfile.close(function (err) {
           t.error(err, 'syncfile closed ok')
+          t.notOk(fs.existsSync(filepath), 'tmp dir deleted')
           t.end()
         })
       })
@@ -41,19 +42,22 @@ test('can initialize with an existing syncfile', function (t) {
   tmp.dir(function (err, dir, cleanup) {
     t.error(err)
 
-    var filepath = path.join(dir, 'sync.tar')
+    var syncDir = tmp.dirSync().name
+    var filepath = path.join(syncDir, 'sync.tar')
 
     setupAndClose(function (err) {
       t.error(err)
       t.ok(fs.existsSync(filepath))
-      t.equal(fs.readdirSync(dir).length, 1)
-      t.notEqual(fs.readdirSync(dir).indexOf('sync.tar'), -1)
+      t.equal(fs.readdirSync(syncDir).length, 1)
+      t.notEqual(fs.readdirSync(syncDir).indexOf('sync.tar'), -1)
+      t.notOk(fs.existsSync(dir), 'tmp dir deleted')
 
       setupAndClose(function (err) {
         t.error(err)
         t.ok(fs.existsSync(filepath))
-        t.equal(fs.readdirSync(dir).length, 1)
-        t.notEqual(fs.readdirSync(dir).indexOf('sync.tar'), -1)
+        t.equal(fs.readdirSync(syncDir).length, 1)
+        t.notEqual(fs.readdirSync(syncDir).indexOf('sync.tar'), -1)
+        t.notOk(fs.existsSync(dir), 'tmp dir deleted')
         t.end()
       })
     })
@@ -71,19 +75,22 @@ test('updates to inner osm-p2p-db.tar entry results in old entry being cleared',
   tmp.dir(function (err, dir, cleanup) {
     t.error(err)
 
-    var filepath = path.join(dir, 'sync.tar')
+    var syncDir = tmp.dirSync().name
+    var filepath = path.join(syncDir, 'sync.tar')
 
     setupAndClose(function (err) {
       t.error(err)
       t.ok(fs.existsSync(filepath))
-      t.equal(fs.readdirSync(dir).length, 1)
-      t.notEqual(fs.readdirSync(dir).indexOf('sync.tar'), -1)
+      t.equal(fs.readdirSync(syncDir).length, 1)
+      t.notOk(fs.existsSync(dir), 'tmp dir deleted')
+      t.notEqual(fs.readdirSync(syncDir).indexOf('sync.tar'), -1)
 
       setupAndClose(function (err) {
         t.error(err)
         t.ok(fs.existsSync(filepath))
-        t.equal(fs.readdirSync(dir).length, 1)
-        t.notEqual(fs.readdirSync(dir).indexOf('sync.tar'), -1)
+        t.equal(fs.readdirSync(syncDir).length, 1)
+        t.notOk(fs.existsSync(dir), 'tmp dir deleted')
+        t.notEqual(fs.readdirSync(syncDir).indexOf('sync.tar'), -1)
 
         var seen = []
         var ex = tar.extract()

--- a/test/create.js
+++ b/test/create.js
@@ -3,6 +3,7 @@ var path = require('path')
 var fs = require('fs')
 var tmp = require('tmp')
 var tar = require('tar-stream')
+var rimraf = require('rimraf')
 var Syncfile = require('..')
 
 test('bad creation', function (t) {
@@ -58,6 +59,7 @@ test('can initialize with an existing syncfile', function (t) {
         t.equal(fs.readdirSync(syncDir).length, 1)
         t.notEqual(fs.readdirSync(syncDir).indexOf('sync.tar'), -1)
         t.notOk(fs.existsSync(dir), 'tmp dir deleted')
+        rimraf.sync(syncDir)
         t.end()
       })
     })
@@ -102,6 +104,7 @@ test('updates to inner osm-p2p-db.tar entry results in old entry being cleared',
         })
         ex.on('finish', function () {
           t.deepEquals(seen.sort(), ['___index.json', 'osm-p2p-db.tar'])
+          rimraf.sync(syncDir)
           t.end()
         })
       })

--- a/test/create.js
+++ b/test/create.js
@@ -16,11 +16,12 @@ test('bad creation', function (t) {
 test('can initialize with new syncfile', function (t) {
   tmp.dir(function (err, dir, cleanup) {
     t.error(err)
-
+    var p2pTmpDir = path.join(dir, 'osm-p2p-syncfile-tmp')
     var filepath = path.join(dir, 'sync.tar')
     var syncfile = Syncfile(filepath, dir)
 
     syncfile.ready(function () {
+      t.ok(fs.existsSync(p2pTmpDir), 'p2p tmp dir created')
       t.ok(fs.existsSync(filepath), 'syncfile dir exists')
       t.equal(fs.readdirSync(dir).length, 2, 'two files in syncfile dir')
       t.notEqual(fs.readdirSync(dir).indexOf('sync.tar'), -1, 'sync.tar is present')
@@ -31,7 +32,7 @@ test('can initialize with new syncfile', function (t) {
 
         syncfile.close(function (err) {
           t.error(err, 'syncfile closed ok')
-          t.notOk(fs.existsSync(filepath), 'tmp dir deleted')
+          t.notOk(fs.existsSync(p2pTmpDir), 'p2p tmp dir deleted')
           t.end()
         })
       })
@@ -43,6 +44,7 @@ test('can initialize with an existing syncfile', function (t) {
   tmp.dir(function (err, dir, cleanup) {
     t.error(err)
 
+    var p2pTmpDir = path.join(dir, 'osm-p2p-syncfile-tmp')
     var syncDir = tmp.dirSync().name
     var filepath = path.join(syncDir, 'sync.tar')
 
@@ -51,14 +53,14 @@ test('can initialize with an existing syncfile', function (t) {
       t.ok(fs.existsSync(filepath))
       t.equal(fs.readdirSync(syncDir).length, 1)
       t.notEqual(fs.readdirSync(syncDir).indexOf('sync.tar'), -1)
-      t.notOk(fs.existsSync(dir), 'tmp dir deleted')
+      t.notOk(fs.existsSync(p2pTmpDir), 'p2p tmp dir deleted')
 
       setupAndClose(function (err) {
         t.error(err)
         t.ok(fs.existsSync(filepath))
         t.equal(fs.readdirSync(syncDir).length, 1)
         t.notEqual(fs.readdirSync(syncDir).indexOf('sync.tar'), -1)
-        t.notOk(fs.existsSync(dir), 'tmp dir deleted')
+        t.notOk(fs.existsSync(p2pTmpDir), 'p2p tmp dir deleted')
         rimraf.sync(syncDir)
         t.end()
       })
@@ -77,6 +79,7 @@ test('updates to inner osm-p2p-db.tar entry results in old entry being cleared',
   tmp.dir(function (err, dir, cleanup) {
     t.error(err)
 
+    var p2pTmpDir = path.join(dir, 'osm-p2p-syncfile-tmp')
     var syncDir = tmp.dirSync().name
     var filepath = path.join(syncDir, 'sync.tar')
 
@@ -84,14 +87,14 @@ test('updates to inner osm-p2p-db.tar entry results in old entry being cleared',
       t.error(err)
       t.ok(fs.existsSync(filepath))
       t.equal(fs.readdirSync(syncDir).length, 1)
-      t.notOk(fs.existsSync(dir), 'tmp dir deleted')
+      t.notOk(fs.existsSync(p2pTmpDir), 'p2p tmp dir deleted')
       t.notEqual(fs.readdirSync(syncDir).indexOf('sync.tar'), -1)
 
       setupAndClose(function (err) {
         t.error(err)
         t.ok(fs.existsSync(filepath))
         t.equal(fs.readdirSync(syncDir).length, 1)
-        t.notOk(fs.existsSync(dir), 'tmp dir deleted')
+        t.notOk(fs.existsSync(p2pTmpDir), 'p2p tmp dir deleted')
         t.notEqual(fs.readdirSync(syncDir).indexOf('sync.tar'), -1)
 
         var seen = []


### PR DESCRIPTION
Fix #18 where tmp folders weren't deleted after a sync.

Simply changed `cleanup` to remove whole `tmp` folder instead of just sync file.

Haven't fixed all tests yet, waiting for some feedback to continue. In this is the right track?